### PR TITLE
test: work with fastify-route-preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^24.0.3",
     "c8": "^10.1.3",
     "fastify": "^5.3.2",
+    "fastify-route-preset": "^0.1.3",
     "tstyche": "^4.0.0",
     "typescript": "^5.8.3",
     "yaml": "^2.8.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -720,7 +720,7 @@ test('routeSelector with "prefix" and "urlPrefix" as an empty array', async (t) 
  * @see https://github.com/inyourtime/fastify-route-preset
  */
 test('should work with "fastify-route-preset" plugin', async (t) => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   t.after(() => fastify.close())
 
@@ -763,6 +763,14 @@ test('should work with "fastify-route-preset" plugin', async (t) => {
         },
         () => {},
       )
+
+      fastify.get(
+        '/bar2',
+        {
+          schema: { querystring: { type: 'object', properties: { name: { type: 'string' } } } },
+        },
+        () => {},
+      )
     },
     {
       preset: {
@@ -778,7 +786,9 @@ test('should work with "fastify-route-preset" plugin', async (t) => {
 
   const definedPathFoo = apiFoo.paths['/foo']?.get
   const definedPathBar = apiBar.paths['/bar']?.get
+  const definedPathBar2 = apiBar.paths['/bar2']?.get
 
   t.assert.ok(definedPathFoo)
   t.assert.ok(definedPathBar)
+  t.assert.ok(definedPathBar2)
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -715,3 +715,70 @@ test('routeSelector with "prefix" and "urlPrefix" as an empty array', async (t) 
     )
   }
 })
+
+/**
+ * @see https://github.com/inyourtime/fastify-route-preset
+ */
+test('should work with "fastify-route-preset" plugin', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(require('fastify-route-preset'), {
+    onPresetRoute: (routeOptions, preset) => {
+      routeOptions.config = {
+        ...preset,
+        ...routeOptions.config,
+      }
+    },
+  })
+
+  await fastify.register(require('..'), {
+    documents: [{ documentRef: 'foo' }, { documentRef: 'bar' }],
+  })
+
+  fastify.register(
+    async (fastify) => {
+      fastify.get(
+        '/foo',
+        {
+          schema: { querystring: { type: 'object', properties: { name: { type: 'string' } } } },
+        },
+        () => {},
+      )
+    },
+    {
+      preset: {
+        documentRef: 'foo',
+      },
+    },
+  )
+
+  fastify.register(
+    async (fastify) => {
+      fastify.get(
+        '/bar',
+        {
+          schema: { querystring: { type: 'object', properties: { name: { type: 'string' } } } },
+        },
+        () => {},
+      )
+    },
+    {
+      preset: {
+        documentRef: 'bar',
+      },
+    },
+  )
+
+  await fastify.ready()
+
+  const apiFoo = await Swagger.validate(fastify[getDecoratorName('foo')]())
+  const apiBar = await Swagger.validate(fastify[getDecoratorName('bar')]())
+
+  const definedPathFoo = apiFoo.paths['/foo']?.get
+  const definedPathBar = apiBar.paths['/bar']?.get
+
+  t.assert.ok(definedPathFoo)
+  t.assert.ok(definedPathBar)
+})

--- a/test/types/index.tst.ts
+++ b/test/types/index.tst.ts
@@ -64,11 +64,11 @@ app.register(fastifyMultipleSwagger, {
       urlPrefix: ['/foo', '/bar'],
       hooks: {
         onRequest: (req, _reply, done) => {
-          expect<string>().type.toBe(req.url)
+          expect(req.url).type.toBe<string>()
           done()
         },
         preHandler: async (req, _reply) => {
-          expect<string>().type.toBe(req.url)
+          expect(req.url).type.toBe<string>()
         },
       },
     },
@@ -83,8 +83,8 @@ app.register(fastifyMultipleSwagger, {
         yaml: '/swagger.yaml',
       },
       routeSelector(routeOptions, url) {
-        expect<string>().type.toBe(url)
-        expect<RouteOptions>().type.toBe(routeOptions)
+        expect(url).type.toBe<string>()
+        expect(routeOptions).type.toBe<RouteOptions>()
         return true
       },
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the "fastify-route-preset" package as a development dependency.

* **Tests**
  * Introduced a new test to verify compatibility and integration with the "fastify-route-preset" plugin, ensuring correct Swagger documentation generation for routes using presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->