### PR TITLE
feat!: reduce complexity in the routeSelector option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ const externalDoc = fastify.getDocument("external");
 | `documentRef` | `string` | ✅ | Unique identifier for the document |
 | `name` | `string` | ❌ | Display name for UI providers |
 | `swaggerOptions` | `object` | ❌ | Configuration passed to [@fastify/swagger](https://github.com/fastify/fastify-swagger) |
-| `routeSelector` | `string \| function` | ❌ | How to select routes: `'ref'`, `'prefix'`, or custom function |
 | `urlPrefix` | `string \| string[]` | ❌ | URL prefix(es) to filter routes |
+| `routeSelector` | `(routeOptions, url) => boolean` | ❌ | How to select routes |
 | `exposeRoute` | `boolean \| object` | ❌ | Control JSON/YAML route exposure |
 | `meta` | `object` | ❌ | Additional metadata for UI configuration |
 | `hooks` | `object` | ❌ | Fastify hooks for document routes |
@@ -100,6 +100,8 @@ const externalDoc = fastify.getDocument("external");
 | **By Reference** | Routes specify `documentRef` in config | `config: { documentRef: "internal" }` |
 | **By URL Prefix** | Routes starting with prefix are included | `urlPrefix: "/api/v1"` |
 | **Custom Function** | Custom logic determines inclusion | `(routeOptions, url) => routeOptions.schema?.tags?.includes('public')` |
+
+> **Note:** `routeSelector` and `urlPrefix` options cannot be used together. Please provide only one.
 
 ## Integration Examples
 
@@ -151,8 +153,7 @@ await fastify.register(SwaggerUI, {
 ```javascript
 {
   documentRef: "v1",
-  urlPrefix: "/api/v1",
-  routeSelector: "prefix"
+  urlPrefix: "/api/v1"
 }
 ```
 
@@ -244,14 +245,13 @@ Get document sources for UI integration.
 ```javascript
 {
   documentRef: "admin",
-  urlPrefix: ["/admin", "/management"],
-  routeSelector: "prefix"
+  urlPrefix: ["/admin", "/management"]
 }
 ```
 
 ## Contributing
 
-Contributions welcome!
+Contributions are welcome!
 
 ## License
 

--- a/examples/route-selector.mjs
+++ b/examples/route-selector.mjs
@@ -21,7 +21,6 @@ await app.register(fastifyMultipleSwagger, {
     },
     {
       documentRef: 'v2',
-      routeSelector: 'prefix',
       urlPrefix: '/api/v2',
       swaggerOptions: {
         openapi: {

--- a/examples/url-prefix.mjs
+++ b/examples/url-prefix.mjs
@@ -7,7 +7,6 @@ await app.register(fastifyMultipleSwagger, {
   documents: [
     {
       documentRef: 'v1',
-      routeSelector: 'prefix',
       urlPrefix: '/api/v1',
       swaggerOptions: {
         openapi: {
@@ -20,7 +19,6 @@ await app.register(fastifyMultipleSwagger, {
     },
     {
       documentRef: 'v2',
-      routeSelector: 'prefix',
       urlPrefix: '/api/v2',
       swaggerOptions: {
         openapi: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ declare module 'fastify' {
     /**
      * Swagger document reference used for this route
      */
-    documentRef?: string
+    documentRef?: string | string[]
   }
 }
 
@@ -77,28 +77,8 @@ declare namespace fastifyMultipleSwagger {
      */
     documentRef: string
     /**
-     * Determines how routes are matched to this Swagger document.
-     *
-     * - 'ref': matches based on the `documentRef` manually assigned to routes config
-     * - 'prefix': matches based on the `urlPrefix` used in the route path
-     * - function: matches based on a custom function
-     *
-     * @default 'ref'
-     *
-     * @example
-     * ```js
-     * routeSelector: 'ref'
-     * routeSelector: 'prefix'
-     * routeSelector: (routeOptions, url) => {
-     *   return routeOptions.config?.documentRef === 'foo' && url.startsWith('/foo')
-     * }
-     * ```
-     */
-    routeSelector?: 'ref' | 'prefix' | ((routeOptions: RouteOptions, url: string) => boolean)
-    /**
      * URL path prefix used to match routes to this Swagger document
      *
-     * Only used when `routeSelector` is set to `'prefix'`.
      * If a route starts with this prefix, it will be associated with this document.
      *
      * Example:
@@ -110,6 +90,17 @@ declare namespace fastifyMultipleSwagger {
      * ```
      */
     urlPrefix?: `/${string}` | Array<`/${string}`>
+    /**
+     * Determines how routes are matched to this Swagger document.
+     *
+     * @example
+     * ```js
+     * routeSelector: (routeOptions, url) => {
+     *   return routeOptions.config?.documentRef === 'foo' && url.startsWith('/foo')
+     * }
+     * ```
+     */
+    routeSelector?: (routeOptions: RouteOptions, url: string) => boolean
     /**
      * Configuration for exposing JSON/YAML routes
      * Can be boolean or object with `json` and `yaml` as booleans or strings

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -2,8 +2,6 @@
 
 const fp = require('fastify-plugin')
 
-const routeSelectors = ['ref', 'prefix']
-
 module.exports = fp((fastify, opts, next) => {
   if (fastify.hasDecorator(opts.swaggerDecorator)) {
     return next(new Error(`documentRef "${opts.documentRef}" already exists`))
@@ -13,20 +11,23 @@ module.exports = fp((fastify, opts, next) => {
     return next(new TypeError('"defaultDocumentRef" option must be a string'))
   }
 
-  const routeSelector = opts.routeSelector || 'ref'
-  if (typeof routeSelector === 'string' && !routeSelectors.includes(routeSelector)) {
+  const routeSelector = opts.routeSelector
+  const urlPrefix = opts.urlPrefix
+
+  if (routeSelector && urlPrefix) {
     return next(
       new TypeError(
-        `"routeSelector" option must be one of ${routeSelectors.map((s) => `"${s}"`).join(', ')} or a function`,
+        '"routeSelector" and "urlPrefix" options cannot be used together. Please provide only one',
       ),
     )
   }
 
-  if (
-    routeSelector === 'prefix' &&
-    (!opts.urlPrefix || (Array.isArray(opts.urlPrefix) && !opts.urlPrefix.length))
-  ) {
-    return next(new TypeError('"urlPrefix" option is required when "routeSelector" is "prefix"'))
+  if (routeSelector && typeof routeSelector !== 'function') {
+    return next(new TypeError('"routeSelector" option must be a function'))
+  }
+
+  if (urlPrefix && typeof urlPrefix !== 'string' && !Array.isArray(urlPrefix)) {
+    return next(new TypeError('"urlPrefix" option must be a string or an array of strings'))
   }
 
   const options = opts.swaggerOptions || {}
@@ -39,20 +40,25 @@ module.exports = fp((fastify, opts, next) => {
 
       let hide
 
-      if (routeSelector === 'ref') {
-        const configDocumentRef = args.route.config?.documentRef || opts.defaultDocumentRef
-        hide = result.schema?.hide
-        if (configDocumentRef !== opts.documentRef && hide !== true) {
-          hide = true
-        }
-      } else if (routeSelector === 'prefix') {
-        const prefixes = Array.isArray(opts.urlPrefix) ? opts.urlPrefix : [opts.urlPrefix]
+      if (routeSelector) {
+        hide = !routeSelector(args.route, result.url)
+      } else if (urlPrefix) {
+        const prefixes = Array.isArray(urlPrefix) ? urlPrefix : [urlPrefix]
         const matchesPrefix = prefixes.some((prefix) => result.url.startsWith(prefix))
+
         if (!matchesPrefix) {
           hide = true
         }
-      } else if (typeof routeSelector === 'function') {
-        hide = !routeSelector(args.route, result.url)
+      } else {
+        const configRefs = [].concat(
+          args.route.config?.documentRef || opts.defaultDocumentRef || [],
+        )
+        const targetRef = opts.documentRef
+        hide = result.schema?.hide
+
+        if (!configRefs.includes(targetRef) && hide !== true) {
+          hide = true
+        }
       }
 
       return {

--- a/test/types/index.tst.ts
+++ b/test/types/index.tst.ts
@@ -1,4 +1,4 @@
-import type { RouteOptions } from 'fastify'
+import type { FastifyContextConfig, RouteOptions } from 'fastify'
 import Fastify from 'fastify'
 import type { OpenAPI } from 'openapi-types'
 import { expect } from 'tstyche'
@@ -26,7 +26,6 @@ app.register(fastifyMultipleSwagger, {
     {
       documentRef: 'foo',
       exposeRoute: false,
-      routeSelector: 'ref',
       swaggerOptions: {
         openapi: {
           info: {
@@ -51,7 +50,6 @@ app.register(fastifyMultipleSwagger, {
         default: true,
         slug: 'foo',
       },
-      routeSelector: 'prefix',
       urlPrefix: '/api/v1',
     },
   ],
@@ -60,7 +58,6 @@ app.register(fastifyMultipleSwagger, {
   documents: [
     {
       documentRef: 'foo',
-      routeSelector: 'prefix',
       urlPrefix: ['/foo', '/bar'],
       hooks: {
         onRequest: (req, _reply, done) => {
@@ -144,6 +141,9 @@ app.route({
   handler: () => {},
 })
 
+expect(app).type.toHaveProperty('getDocumentSources')
+expect(app).type.toHaveProperty('getDocument')
+
 expect(app.getDocumentSources()).type.toBe<Array<DocumentSource>>()
 expect(app.getDocumentSources({ scalar: true })).type.toBe<Array<ScalarSource>>()
 expect(app.getDocumentSources({ swaggerUI: true })).type.toBe<Array<SwaggerUISource>>()
@@ -154,3 +154,11 @@ expect(app.getDocument).type.not.toBeCallableWith()
 expect(app.getDocument('foo')).type.toBe<OpenAPI.Document>()
 expect(app.getDocument('foo', { yaml: false })).type.toBe<OpenAPI.Document>()
 expect(app.getDocument('foo', { yaml: true })).type.toBe<string>()
+
+expect({ documentRef: 'foo', routeSelector: 'ref' }).type.not.toBeAssignableTo<DocumentConfig>()
+expect({ documentRef: 'foo', routeSelector: 'prefix' }).type.not.toBeAssignableTo<DocumentConfig>()
+expect({ documentRef: 'foo', routeSelector: () => true }).type.toBeAssignableTo<DocumentConfig>()
+
+expect({ documentRef: true }).type.not.toBeAssignableTo<FastifyContextConfig>()
+expect({ documentRef: 'foo' }).type.toBeAssignableTo<FastifyContextConfig>()
+expect({ documentRef: ['foo', 'bar'] }).type.toBeAssignableTo<FastifyContextConfig>()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that `routeSelector` now only accepts a function, not string values, and cannot be used together with `urlPrefix`. Examples and configuration snippets were revised accordingly.
  * Improved wording and added notes about mutual exclusivity of options.

* **New Features**
  * Added support for specifying multiple document references per route.

* **Bug Fixes**
  * Enforced stricter validation for `routeSelector` and `urlPrefix` options, providing clearer error messages for invalid configurations.

* **Refactor**
  * Simplified route selection logic by removing deprecated string-based selectors in favor of a function or URL prefix.

* **Tests**
  * Updated and extended test suite to reflect new validation rules, removed deprecated usage, and added tests for new behaviors and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->