### PR TITLE
feat!: migrate fastify-multiple-swagger to ESM

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import type { FastifyDynamicSwaggerOptions, FastifyStaticSwaggerOptions } from '@fastify/swagger'
 import type {
-  FastifyPluginAsync,
+  FastifyPluginCallback,
   onRequestHookHandler,
   preHandlerHookHandler,
   RouteOptions,
@@ -19,9 +19,9 @@ declare module 'fastify' {
      * fastify.getDocumentSources({ swaggerUI: true })
      * ```
      */
-    getDocumentSources: (() => Array<fastifyMultipleSwagger.DocumentSource>) &
-      ((opts: { scalar: true }) => Array<fastifyMultipleSwagger.ScalarSource>) &
-      ((opts: { swaggerUI: true }) => Array<fastifyMultipleSwagger.SwaggerUISource>)
+    getDocumentSources: (() => Array<DocumentSource>) &
+      ((opts: { scalar: true }) => Array<ScalarSource>) &
+      ((opts: { swaggerUI: true }) => Array<SwaggerUISource>)
 
     /**
      * Returns a swagger document by documentRef
@@ -47,158 +47,149 @@ declare module 'fastify' {
   }
 }
 
-type FastifyMultipleSwagger =
-  FastifyPluginAsync<fastifyMultipleSwagger.FastifyMultipleSwaggerOptions>
+export type FastifyMultipleSwagger = FastifyPluginCallback<FastifyMultipleSwaggerOptions>
 
-declare namespace fastifyMultipleSwagger {
-  export interface FastifyMultipleSwaggerOptions {
-    /**
-     * Array of document configurations or documentRef names (required)
-     */
-    documents: Array<string | DocumentConfig>
-    /**
-     * Default documentRef name for routes without explicit documentRef
-     * @default undefined
-     */
-    defaultDocumentRef?: string
-    /**
-     * Global prefix for all document routes (json and yaml)
-     */
-    routePrefix?: `/${string}`
-  }
-
-  export type SwaggerOptions =
-    | FastifyStaticSwaggerOptions
-    | Omit<FastifyDynamicSwaggerOptions, 'decorator'>
-
-  export interface DocumentConfig {
-    /**
-     * Unique reference name for the Swagger document
-     */
-    documentRef: string
-    /**
-     * URL path prefix used to match routes to this Swagger document
-     *
-     * If a route starts with this prefix, it will be associated with this document.
-     *
-     * Example:
-     * ```js
-     * urlPrefix: '/admin'
-     * // Routes like /admin/users or /admin/settings will be matched to this document
-     * urlPrefix: ['/admin', '/customer']
-     * // Routes like /admin/settings or /customer/profile will be matched to this document
-     * ```
-     */
-    urlPrefix?: `/${string}` | Array<`/${string}`>
-    /**
-     * Determines how routes are matched to this Swagger document.
-     *
-     * @example
-     * ```js
-     * routeSelector: (routeOptions, url) => {
-     *   return routeOptions.config?.documentRef === 'foo' && url.startsWith('/foo')
-     * }
-     * ```
-     */
-    routeSelector?: (routeOptions: RouteOptions, url: string) => boolean
-    /**
-     * Configuration for exposing JSON/YAML routes
-     * Can be boolean or object with `json` and `yaml` as booleans or strings
-     * If `json` and `yaml` are strings, they will be used as route paths
-     *
-     * @default true
-     *
-     * @example
-     * ```js
-     * exposeRoute: {
-     *   json: '/swagger.json',
-     *   yaml: '/swagger.yaml',
-     * }
-     *
-     * exposeRoute: {
-     *   json: '/swagger.json',
-     *   yaml: false,
-     * }
-     * ```
-     */
-    exposeRoute?: ExposeRouteOptions
-    /**
-     * Configuration passed to @fastify/swagger
-     * @see https://github.com/fastify/fastify-swagger?tab=readme-ov-file#api
-     */
-    swaggerOptions?: SwaggerOptions
-    /**
-     * Display name for the UI providers
-     */
-    name?: string
-    /**
-     * Additional metadata for UI providers configuration
-     */
-    meta?: {
-      [key: string]: any
-    }
-    /**
-     * The hooks to use for this document
-     * 
-     * @example
-     * ```js
-     * hooks: {
-     *   onRequest: (req, _reply, done) => {
-     *    console.log(req.url)
-     *    done()
-     *   },
-     * }
-     * ```
-     }
-     */
-    hooks?: HooksOptions
-  }
-
-  export type ExposeRouteOptions =
-    | {
-        json?: string | boolean
-        yaml?: string | boolean
-      }
-    | boolean
-
-  export type DocumentSource = {
-    /**
-     * Unique reference name for the Swagger document
-     */
-    documentRef: string
-    /**
-     * Url for JSON route
-     * @default `/doc-${index}/json`
-     */
-    json: string | null
-    /**
-     * Url for YAML route
-     * @default `/doc-${index}/yaml`
-     */
-    yaml: string | null
-  }
-
-  export type ScalarSource = {
-    url: string
-    title: string
-    [key: string]: any
-  }
-
-  export type SwaggerUISource = {
-    url: string
-    name: string
-  }
-
-  export type HooksOptions = Partial<{
-    onRequest?: onRequestHookHandler
-    preHandler?: preHandlerHookHandler
-  }>
-
-  export const fastifyMultipleSwagger: FastifyMultipleSwagger
-  export { fastifyMultipleSwagger as default }
+export interface FastifyMultipleSwaggerOptions {
+  /**
+   * Array of document configurations or documentRef names (required)
+   */
+  documents: Array<string | DocumentConfig>
+  /**
+   * Default documentRef name for routes without explicit documentRef
+   * @default undefined
+   */
+  defaultDocumentRef?: string
+  /**
+   * Global prefix for all document routes (json and yaml)
+   */
+  routePrefix?: `/${string}`
 }
 
-declare function fastifyMultipleSwagger(
-  ...params: Parameters<FastifyMultipleSwagger>
-): ReturnType<FastifyMultipleSwagger>
-export = fastifyMultipleSwagger
+export type SwaggerOptions =
+  | FastifyStaticSwaggerOptions
+  | Omit<FastifyDynamicSwaggerOptions, 'decorator'>
+
+export interface DocumentConfig {
+  /**
+   * Unique reference name for the Swagger document
+   */
+  documentRef: string
+  /**
+   * URL path prefix used to match routes to this Swagger document
+   *
+   * If a route starts with this prefix, it will be associated with this document.
+   *
+   * Example:
+   * ```js
+   * urlPrefix: '/admin'
+   * // Routes like /admin/users or /admin/settings will be matched to this document
+   * urlPrefix: ['/admin', '/customer']
+   * // Routes like /admin/settings or /customer/profile will be matched to this document
+   * ```
+   */
+  urlPrefix?: `/${string}` | Array<`/${string}`>
+  /**
+   * Determines how routes are matched to this Swagger document.
+   *
+   * @example
+   * ```js
+   * routeSelector: (routeOptions, url) => {
+   *   return routeOptions.config?.documentRef === 'foo' && url.startsWith('/foo')
+   * }
+   * ```
+   */
+  routeSelector?: (routeOptions: RouteOptions, url: string) => boolean
+  /**
+   * Configuration for exposing JSON/YAML routes
+   * Can be boolean or object with `json` and `yaml` as booleans or strings
+   * If `json` and `yaml` are strings, they will be used as route paths
+   *
+   * @default true
+   *
+   * @example
+   * ```js
+   * exposeRoute: {
+   *   json: '/swagger.json',
+   *   yaml: '/swagger.yaml',
+   * }
+   *
+   * exposeRoute: {
+   *   json: '/swagger.json',
+   *   yaml: false,
+   * }
+   * ```
+   */
+  exposeRoute?: ExposeRouteOptions
+  /**
+   * Configuration passed to @fastify/swagger
+   * @see https://github.com/fastify/fastify-swagger?tab=readme-ov-file#api
+   */
+  swaggerOptions?: SwaggerOptions
+  /**
+   * Display name for the UI providers
+   */
+  name?: string
+  /**
+   * Additional metadata for UI providers configuration
+   */
+  meta?: {
+    [key: string]: any
+  }
+  /**
+   * The hooks to use for this document
+   *
+   * @example
+   * ```js
+   * hooks: {
+   *   onRequest: (req, _reply, done) => {
+   *    console.log(req.url)
+   *    done()
+   *   },
+   * }
+   * ```
+   */
+  hooks?: HooksOptions
+}
+
+export type ExposeRouteOptions =
+  | {
+      json?: string | boolean
+      yaml?: string | boolean
+    }
+  | boolean
+
+export type DocumentSource = {
+  /**
+   * Unique reference name for the Swagger document
+   */
+  documentRef: string
+  /**
+   * Url for JSON route
+   * @default `/doc-${index}/json`
+   */
+  json: string | null
+  /**
+   * Url for YAML route
+   * @default `/doc-${index}/yaml`
+   */
+  yaml: string | null
+}
+
+export type ScalarSource = {
+  url: string
+  title: string
+  [key: string]: any
+}
+
+export type SwaggerUISource = {
+  url: string
+  name: string
+}
+
+export type HooksOptions = Partial<{
+  onRequest?: onRequestHookHandler
+  preHandler?: preHandlerHookHandler
+}>
+
+export declare const fastifyMultipleSwagger: FastifyMultipleSwagger
+export default fastifyMultipleSwagger

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-'use strict'
-
-const fp = require('fastify-plugin')
-const { getExposeRouteOptions, getDecoratorName } = require('./lib/utils')
+import fp from 'fastify-plugin'
+import routePlugin from './lib/route.js'
+import swaggerPlugin from './lib/swagger.js'
+import { getDecoratorName, getExposeRouteOptions } from './lib/utils.js'
 
 /**
  * @type {import('fastify').FastifyPluginCallback<import('.').FastifyMultipleSwaggerOptions>}
@@ -24,7 +24,7 @@ function plugin(fastify, opts, next) {
     const swaggerDecorator = getDecoratorName(normalizedOptions.documentRef)
 
     // Register swagger instance
-    fastify.register(require('./lib/swagger'), {
+    fastify.register(swaggerPlugin, {
       ...normalizedOptions,
       defaultDocumentRef: opts.defaultDocumentRef,
       swaggerDecorator,
@@ -34,7 +34,7 @@ function plugin(fastify, opts, next) {
     const routePrefix = opts.routePrefix
 
     // Register route for json/yaml
-    fastify.register(require('./lib/route'), {
+    fastify.register(routePlugin, {
       ...opts,
       prefix: routePrefix,
       ...routeConfig,
@@ -115,7 +115,7 @@ function normalizeDocumentOptions(documentOptions) {
 
 /**
  * @typedef {Object} RouteConfig
- * @property {import('./lib/utils').ExposeRouteOptions} exposeRoute - The expose route options
+ * @property {import('./lib/utils.js').ExposeRouteOptions} exposeRoute - The expose route options
  * @property {string} jsonPath - The path to the JSON documentation
  * @property {string} yamlPath - The path to the YAML documentation
  */
@@ -180,6 +180,6 @@ const fastifyMultipleSwagger = fp(plugin, {
   fastify: '5.x',
   name: 'fastify-multiple-swagger',
 })
-module.exports = fastifyMultipleSwagger
-module.exports.default = fastifyMultipleSwagger
-module.exports.fastifyMultipleSwagger = fastifyMultipleSwagger
+
+export { fastifyMultipleSwagger }
+export default fastifyMultipleSwagger

--- a/lib/route.js
+++ b/lib/route.js
@@ -1,9 +1,7 @@
-'use strict'
-
 /**
  * @type {import('fastify').FastifyPluginCallback<>}
  */
-module.exports = (fastify, opts, next) => {
+export default function routePlugin(fastify, opts, next) {
   const hooks = Object.create(null)
   if (opts.hooks) {
     const additionalHooks = ['onRequest', 'preHandler']

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -1,8 +1,7 @@
-'use strict'
+import swagger from '@fastify/swagger'
+import fp from 'fastify-plugin'
 
-const fp = require('fastify-plugin')
-
-module.exports = fp((fastify, opts, next) => {
+export default fp((fastify, opts, next) => {
   if (fastify.hasDecorator(opts.swaggerDecorator)) {
     return next(new Error(`documentRef "${opts.documentRef}" already exists`))
   }
@@ -33,7 +32,7 @@ module.exports = fp((fastify, opts, next) => {
   const options = opts.swaggerOptions || {}
   const { transform: transformFunc, ...swaggerOptions } = options
 
-  fastify.register(require('@fastify/swagger'), {
+  fastify.register(swagger, {
     transform: (args) => {
       // First call transform option if provided
       const result = transformFunc ? transformFunc(args) : { schema: args.schema, url: args.url }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,3 @@
-'use strict'
-
 /**
  * @typedef {Object} ExposeRouteOptions
  * @property {boolean | string} [json]
@@ -17,7 +15,7 @@
  * @returns {ExposeRouteOptions} An object with `json` and `yaml` booleans
  *   indicating whether to exposeRoute each format, or the original object if `exposeRoute` is already one.
  */
-function getExposeRouteOptions(exposeRoute) {
+export function getExposeRouteOptions(exposeRoute) {
   if (typeof exposeRoute === 'object') {
     return exposeRoute
   }
@@ -42,8 +40,6 @@ function getExposeRouteOptions(exposeRoute) {
  *
  * @returns {string} A unique decorator name.
  */
-function getDecoratorName(documentRef) {
+export function getDecoratorName(documentRef) {
   return `multipleSwagger-${documentRef}`
 }
-
-module.exports = { getExposeRouteOptions, getDecoratorName }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "fastify-multiple-swagger",
   "version": "2.1.0",
   "description": "A Fastify plugin for generating multiple Swagger/OpenAPI documents using @fastify/swagger.",
-  "type": "commonjs",
-  "main": "index.js",
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "types": "index.d.ts",
   "scripts": {
     "lint": "biome check",

--- a/test-types/index.tst.ts
+++ b/test-types/index.tst.ts
@@ -8,8 +8,8 @@ import type {
   FastifyMultipleSwaggerOptions,
   ScalarSource,
   SwaggerUISource,
-} from '..'
-import fastifyMultipleSwagger from '..'
+} from '../index.js'
+import fastifyMultipleSwagger from '../index.js'
 
 const app = Fastify()
 

--- a/test/hook.test.js
+++ b/test/hook.test.js
@@ -1,7 +1,7 @@
-'use strict'
-
-const { test } = require('node:test')
-const Fastify = require('fastify')
+import { test } from 'node:test'
+import basicAuth from '@fastify/basic-auth'
+import Fastify from 'fastify'
+import fastifyMultipleSwagger from '../index.js'
 
 const authOptions = {
   validate(username, password, _req, _reply, done) {
@@ -25,7 +25,7 @@ test('should work with hook', async (t) => {
 
   let hit = 0
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'foo',
@@ -69,9 +69,9 @@ test('returns 200 OK for protected route with basic auth', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('@fastify/basic-auth'), authOptions)
+  await fastify.register(basicAuth, authOptions)
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'foo',
@@ -106,9 +106,9 @@ test('returns 401 for protected route with basic auth', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('@fastify/basic-auth'), authOptions)
+  await fastify.register(basicAuth, authOptions)
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'foo',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,16 +1,16 @@
-'use strict'
-
-const { test } = require('node:test')
-const Fastify = require('fastify')
-const Swagger = require('@apidevtools/swagger-parser')
-const yaml = require('yaml')
-const { getDecoratorName } = require('../lib/utils')
+import { test } from 'node:test'
+import Swagger from '@apidevtools/swagger-parser'
+import Fastify from 'fastify'
+import routePreset from 'fastify-route-preset'
+import yaml from 'yaml'
+import fastifyMultipleSwagger from '../index.js'
+import { getDecoratorName } from '../lib/utils.js'
 
 test('register plugin success', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
-  await fastify.register(require('..'), { documents: [] })
+  await fastify.register(fastifyMultipleSwagger, { documents: [] })
 
   t.assert.ok(fastify.hasPlugin('fastify-multiple-swagger'))
 })
@@ -20,7 +20,7 @@ test('should generate multiple documents #documentRef', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), { documents: ['foo', 'bar'] })
+  await fastify.register(fastifyMultipleSwagger, { documents: ['foo', 'bar'] })
 
   fastify.get(
     '/foo',
@@ -68,7 +68,7 @@ test('should generate multiple documents #endpoint', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), { documents: ['foo', 'bar'] })
+  await fastify.register(fastifyMultipleSwagger, { documents: ['foo', 'bar'] })
 
   fastify.get(
     '/foo',
@@ -118,7 +118,7 @@ test('invalid "documents" option #1', async (t) => {
   const fastify = Fastify()
 
   try {
-    await fastify.register(require('..'), { documents: 'foo' })
+    await fastify.register(fastifyMultipleSwagger, { documents: 'foo' })
   } catch (err) {
     t.assert.ok(err)
     t.assert.strictEqual(err.message, '"documents" option must be an array')
@@ -130,7 +130,7 @@ test('invalid "documents" option #2', async (t) => {
   const fastify = Fastify()
 
   try {
-    await fastify.register(require('..'), { documents: [1, 2] })
+    await fastify.register(fastifyMultipleSwagger, { documents: [1, 2] })
   } catch (err) {
     t.assert.ok(err)
     t.assert.strictEqual(err.message, '"documents" option must be an array of objects or strings')
@@ -142,7 +142,9 @@ test('"exposeRoute" option is false', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), { documents: [{ documentRef: 'foo', exposeRoute: false }] })
+  await fastify.register(fastifyMultipleSwagger, {
+    documents: [{ documentRef: 'foo', exposeRoute: false }],
+  })
 
   await fastify.ready()
 
@@ -155,7 +157,7 @@ test('"exposeRoute" option is object', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'foo', exposeRoute: { json: false, yaml: true } }],
   })
 
@@ -170,7 +172,7 @@ test('"exposeRoute" option with route url', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       { documentRef: 'foo', exposeRoute: { json: '/swagger.json', yaml: '/swagger.yaml' } },
     ],
@@ -187,7 +189,7 @@ test('provide "routePrefix" option', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       { documentRef: 'foo', exposeRoute: { json: '/swagger.json', yaml: '/swagger.yaml' } },
     ],
@@ -205,7 +207,7 @@ test('invalid "documentRef" option', async (t) => {
   const fastify = Fastify()
 
   try {
-    await fastify.register(require('..'), { documents: [{ documentRef: null }] })
+    await fastify.register(fastifyMultipleSwagger, { documents: [{ documentRef: null }] })
   } catch (err) {
     t.assert.ok(err)
     t.assert.strictEqual(err.message, '"documentRef" option must be a string')
@@ -217,7 +219,7 @@ test('duplicate "documentRef" option', async (t) => {
   const fastify = Fastify()
 
   try {
-    await fastify.register(require('..'), {
+    await fastify.register(fastifyMultipleSwagger, {
       documents: [{ documentRef: 'foo' }, { documentRef: 'foo' }],
     })
   } catch (err) {
@@ -231,7 +233,7 @@ test('invalid "defaultDocumentRef" option', async (t) => {
   const fastify = Fastify()
 
   try {
-    await fastify.register(require('..'), {
+    await fastify.register(fastifyMultipleSwagger, {
       documents: [{ documentRef: 'foo' }],
       defaultDocumentRef: true,
     })
@@ -246,7 +248,7 @@ test('should work with "defaultDocumentRef"', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'foo' }, { documentRef: 'bar' }],
     defaultDocumentRef: 'foo',
   })
@@ -271,7 +273,7 @@ test('should work with swagger transform', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'foo',
@@ -295,7 +297,7 @@ test('should have decorator getDocumentSources', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       { documentRef: 'foo', exposeRoute: { json: '/swagger.json', yaml: '/swagger.yaml' } },
     ],
@@ -314,7 +316,7 @@ test('routePrefix end with slash', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       { documentRef: 'foo', exposeRoute: { json: '/swagger.json', yaml: '/swagger.yaml' } },
     ],
@@ -337,7 +339,7 @@ test('getDocumentSources with no exposeRoute', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'foo', exposeRoute: false }],
   })
 
@@ -359,7 +361,7 @@ test('getDocumentSources with scalar option', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'foo',
@@ -394,7 +396,7 @@ test('getDocumentSources with swaggerUI option', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'foo',
@@ -422,7 +424,7 @@ test('getDocumentSources with invalid option', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'foo',
@@ -453,7 +455,7 @@ test('getDocument with valid documentRef', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: ['foo', 'bar'],
   })
 
@@ -472,7 +474,7 @@ test('getDocument with invalid documentRef', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: ['foo', 'bar'],
   })
 
@@ -495,7 +497,7 @@ test('getDocument with YAML option', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: ['foo'],
   })
 
@@ -513,7 +515,7 @@ test('should work with only "documentRef" option', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'foo' }],
   })
 
@@ -554,7 +556,7 @@ test('should work with "urlPrefix" option', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'foo', urlPrefix: '/foo' }],
   })
 
@@ -589,7 +591,7 @@ test('should work with "routeSelector" option', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'foo',
@@ -633,7 +635,7 @@ test('invalid routeSelector', async (t) => {
   t.after(() => fastify.close())
 
   try {
-    await fastify.register(require('..'), {
+    await fastify.register(fastifyMultipleSwagger, {
       documents: [{ documentRef: 'foo', routeSelector: 'foo' }],
     })
   } catch (err) {
@@ -647,7 +649,7 @@ test('should work with "urlPrefix" option as array', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'foo', urlPrefix: ['/foo', '/bar'] }],
   })
 
@@ -683,7 +685,7 @@ test("should error when both 'routeSelector' and 'urlPrefix' are set", async (t)
   t.after(() => fastify.close())
 
   try {
-    await fastify.register(require('..'), {
+    await fastify.register(fastifyMultipleSwagger, {
       documents: [
         {
           documentRef: 'foo',
@@ -707,7 +709,7 @@ test('invalid "urlPrefix" option', async (t) => {
   t.after(() => fastify.close())
 
   try {
-    await fastify.register(require('..'), {
+    await fastify.register(fastifyMultipleSwagger, {
       documents: [{ documentRef: 'foo', urlPrefix: 1 }],
     })
   } catch (err) {
@@ -724,7 +726,7 @@ test('should work with "fastify-route-preset" plugin', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  fastify.register(require('fastify-route-preset'), {
+  fastify.register(routePreset, {
     onPresetRoute: (routeOptions, preset) => {
       routeOptions.config = {
         ...preset,
@@ -733,7 +735,7 @@ test('should work with "fastify-route-preset" plugin', async (t) => {
     },
   })
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'foo' }, { documentRef: 'bar' }],
   })
 
@@ -798,7 +800,7 @@ test('should work with config "documentRef" as a array', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'foo' }, { documentRef: 'bar' }],
   })
 

--- a/test/scalar.test.js
+++ b/test/scalar.test.js
@@ -1,15 +1,14 @@
-'use strict'
-
-const { test } = require('node:test')
-const Fastify = require('fastify')
-const Scalar = require('@scalar/fastify-api-reference')
+import { test } from 'node:test'
+import Scalar from '@scalar/fastify-api-reference'
+import Fastify from 'fastify'
+import fastifyMultipleSwagger from '../index.js'
 
 test('should work with scalar #default config', async (t) => {
   t.plan(5)
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'swagger1' }, { documentRef: 'swagger2' }],
   })
 
@@ -37,7 +36,7 @@ test('should work with scalar #custom config', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'swagger1',

--- a/test/swagger-ui.test.js
+++ b/test/swagger-ui.test.js
@@ -1,15 +1,14 @@
-'use strict'
-
-const { test } = require('node:test')
-const Fastify = require('fastify')
-const SwaggerUI = require('@fastify/swagger-ui')
+import { test } from 'node:test'
+import SwaggerUI from '@fastify/swagger-ui'
+import Fastify from 'fastify'
+import fastifyMultipleSwagger from '../index.js'
 
 test('should work with swagger-ui #default config', async (t) => {
   t.plan(4)
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [{ documentRef: 'swagger1' }, { documentRef: 'swagger2' }],
   })
 
@@ -37,7 +36,7 @@ test('should work with swagger-ui #custom config', async (t) => {
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  await fastify.register(require('..'), {
+  await fastify.register(fastifyMultipleSwagger, {
     documents: [
       {
         documentRef: 'swagger1',


### PR DESCRIPTION
## Summary
- Converted the plugin runtime to native ESM and updated package metadata for ESM exports
- Reworked internal modules, tests, and type declarations to use ESM imports/exports
- Preserved the public API, including default and named plugin exports

## Testing
- `npm run lint`
- `npm test`
- Verified ESM import compatibility with a direct module smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched package to native ES modules for improved runtime compatibility.
  * Updated plugin export shape to align with ESM conventions.
  * Reorganized TypeScript declarations to expose options and source types at top level for clearer typing.

* **Chores**
  * Migrated tests to ESM syntax.

* **User-facing behavior**
  * Default documentation route URLs were adjusted (updated paths for JSON docs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->